### PR TITLE
feat: AI decision explanation layer (#176)

### DIFF
--- a/apps/aviation-accident-tracker/backend/package.json
+++ b/apps/aviation-accident-tracker/backend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@apollo/server": "^5.4.0",
     "@as-integrations/express5": "^1.0.0",
+    "@aviation/ai-explainer": "*",
     "@aviation/keystore": "*",
     "@aviation/shared-sdk": "*",
     "@graphql-tools/schema": "^10.0.2",

--- a/apps/aviation-accident-tracker/backend/src/api/routes.ts
+++ b/apps/aviation-accident-tracker/backend/src/api/routes.ts
@@ -6,6 +6,7 @@ import { searchAirports } from '../geo/airportLookup.js';
 import { EventRepository } from '../db/repository.js';
 import { config } from '../config.js';
 import { beadsIssueCreator } from '../beads.js';
+import { ExplainerClient, isExplainError } from '@aviation/ai-explainer';
 
 type BeadsErrorReport = {
   source: 'frontend' | 'backend' | 'log' | string;
@@ -15,6 +16,8 @@ type BeadsErrorReport = {
   user_agent?: string | null;
   context?: Record<string, unknown>;
 };
+
+const explainerClient = new ExplainerClient();
 
 export function createRouter(repository: EventRepository) {
   const router = express.Router();
@@ -339,6 +342,49 @@ export function createRouter(repository: EventRepository) {
     const regions: string[] = []; // Regions not currently supported
 
     return res.json({ countries, regions });
+  });
+
+  /**
+   * @openapi
+   * /api/explain:
+   *   post:
+   *     summary: Explain an AI decision via the RCC brain API
+   *     tags: [AI]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [context, question]
+   *             properties:
+   *               context:
+   *                 type: string
+   *               question:
+   *                 type: string
+   *     responses:
+   *       200:
+   *         description: AI explanation
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 explanation:
+   *                   type: string
+   *       503:
+   *         description: AI explanation service unavailable
+   */
+  router.post('/explain', async (req, res) => {
+    const { context, question } = req.body as { context?: string; question?: string };
+    if (!context || !question) {
+      return res.status(400).json({ error: 'context and question are required' });
+    }
+    const result = await explainerClient.explain({ context, question });
+    if (isExplainError(result)) {
+      return res.status(result.status).json({ error: result.error });
+    }
+    return res.json({ explanation: result.explanation });
   });
 
   return router;

--- a/apps/aviation-accident-tracker/frontend/src/App.tsx
+++ b/apps/aviation-accident-tracker/frontend/src/App.tsx
@@ -92,6 +92,47 @@ export function App() {
   const [selected, setSelected] = useState<EventRecord | null>(null);
   const [selectedLoading, setSelectedLoading] = useState(false);
   const [selectedError, setSelectedError] = useState<string | null>(null);
+
+  // AI Explainer
+  const [explainLoading, setExplainLoading] = useState(false);
+  const [explainText, setExplainText] = useState<string | null>(null);
+  const [explainError, setExplainError] = useState<string | null>(null);
+
+  const handleExplain = async (event: EventRecord) => {
+    setExplainLoading(true);
+    setExplainText(null);
+    setExplainError(null);
+    try {
+      const context = [
+        `Aircraft: ${event.aircraftType || 'unknown'}`,
+        `Registration: ${event.registration}`,
+        `Operator: ${event.operator || 'unknown'}`,
+        `Date: ${event.dateZ}`,
+        `Category: ${event.category}`,
+        `Country: ${event.country || 'unknown'}`,
+        `Fatalities: ${event.fatalities ?? 'unknown'}`,
+        `Injuries: ${event.injuries ?? 'unknown'}`,
+        `Summary: ${event.summary || 'n/a'}`,
+        `Narrative: ${event.narrative || 'n/a'}`,
+      ].join('\n');
+      const question = 'Why did this aviation accident occur and what factors contributed to it?';
+      const res = await fetch('/api/explain', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ context, question }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setExplainError(data.error || `Error ${res.status}`);
+      } else {
+        setExplainText(data.explanation);
+      }
+    } catch (err) {
+      setExplainError(err instanceof Error ? err.message : 'Failed to get explanation');
+    } finally {
+      setExplainLoading(false);
+    }
+  };
   const [airportQuery, setAirportQuery] = useState('');
   const [airportOptions, setAirportOptions] = useState<{ label: string; code: string }[]>([]);
   const [country, setCountry] = useState('');
@@ -590,7 +631,27 @@ export function App() {
                   : '—'}
             </p>
             {selectedError && <p style={{ color: 'red' }}>Failed to load event detail: {selectedError}</p>}
-            <button onClick={() => setSelected(null)}>Close</button>
+
+            {/* AI Explainer */}
+            <div style={{ marginTop: 16, borderTop: '1px solid #eee', paddingTop: 12 }}>
+              <button
+                onClick={() => handleExplain(selected)}
+                disabled={explainLoading}
+                title="Ask AI to explain this accident"
+                style={{ background: '#1a73e8', color: 'white', border: 'none', borderRadius: 4, padding: '6px 14px', cursor: explainLoading ? 'wait' : 'pointer' }}
+              >
+                {explainLoading ? '⏳ Thinking…' : '? Explain with AI'}
+              </button>
+              {explainError && <p style={{ color: 'red', marginTop: 8 }}>{explainError}</p>}
+              {explainText && (
+                <div style={{ marginTop: 10, background: '#f0f4ff', borderRadius: 6, padding: 12, fontSize: 14 }}>
+                  <strong>AI Explanation:</strong>
+                  <p style={{ marginTop: 6, whiteSpace: 'pre-wrap' }}>{explainText}</p>
+                </div>
+              )}
+            </div>
+
+            <button style={{ marginTop: 12 }} onClick={() => { setSelected(null); setExplainText(null); setExplainError(null); }}>Close</button>
           </div>
         </div>
       )}

--- a/packages/ai-explainer/README.md
+++ b/packages/ai-explainer/README.md
@@ -1,0 +1,38 @@
+# @aviation/ai-explainer
+
+Shared AI decision explanation client for Aviation monorepo apps.
+
+## Overview
+
+`ExplainerClient` calls the RCC brain API to answer "why did you make this decision?" questions. It accepts a `context` string (relevant data/state) and a `question` string, and returns a natural-language explanation.
+
+## Configuration
+
+Set the `RCC_URL` environment variable to point at your RCC brain API instance (default: `http://localhost:8789`).
+
+## Usage
+
+```typescript
+import { ExplainerClient, isExplainError } from '@aviation/ai-explainer';
+
+const client = new ExplainerClient(); // reads RCC_URL from env
+
+const result = await client.explain({
+  context: 'Flight summary and relevant data...',
+  question: 'Why was this route recommended?',
+});
+
+if (isExplainError(result)) {
+  console.error(`Error ${result.status}: ${result.error}`);
+} else {
+  console.log(result.explanation);
+}
+```
+
+## Backend Integration
+
+Each app backend exposes `POST /api/explain` accepting `{ context: string, question: string }` and returning `{ explanation: string }`. Returns 503 if RCC is unreachable.
+
+## Frontend Integration
+
+A `? Explain with AI` button appears in event detail modals, calling `/api/explain` and displaying the response inline.

--- a/packages/ai-explainer/package.json
+++ b/packages/ai-explainer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@aviation/ai-explainer",
+  "version": "0.1.0",
+  "description": "Shared AI decision explanation client for Aviation apps",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "echo \"(placeholder)\""
+  },
+  "keywords": ["aviation", "ai", "explainer"],
+  "author": "Jordan Hubbard",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^25.3.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/ai-explainer/src/ExplainerClient.ts
+++ b/packages/ai-explainer/src/ExplainerClient.ts
@@ -1,0 +1,65 @@
+/**
+ * ExplainerClient — calls the RCC brain API to explain AI decisions.
+ *
+ * Configurable via the RCC_URL environment variable.
+ * Defaults to http://localhost:8789.
+ * Gracefully returns a 503-style error object if RCC is unreachable.
+ */
+
+export interface ExplainRequest {
+  context: string;
+  question: string;
+}
+
+export interface ExplainResponse {
+  explanation: string;
+}
+
+export interface ExplainError {
+  error: string;
+  status: number;
+}
+
+export type ExplainResult = ExplainResponse | ExplainError;
+
+export function isExplainError(result: ExplainResult): result is ExplainError {
+  return 'error' in result;
+}
+
+export class ExplainerClient {
+  private readonly rccUrl: string;
+
+  constructor(rccUrl?: string) {
+    this.rccUrl = rccUrl ?? process.env['RCC_URL'] ?? 'http://localhost:8789';
+  }
+
+  async explain(request: ExplainRequest): Promise<ExplainResult> {
+    const url = `${this.rccUrl}/api/explain`;
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => response.statusText);
+        return { error: `RCC returned ${response.status}: ${text}`, status: response.status };
+      }
+
+      const data = await response.json() as ExplainResponse;
+      return data;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isTimeout = message.includes('timeout') || message.includes('TimeoutError') || message.includes('AbortError');
+      return {
+        error: isTimeout
+          ? 'AI explanation service timed out'
+          : `AI explanation service unavailable: ${message}`,
+        status: 503,
+      };
+    }
+  }
+}

--- a/packages/ai-explainer/src/index.ts
+++ b/packages/ai-explainer/src/index.ts
@@ -1,0 +1,2 @@
+export { ExplainerClient, isExplainError } from './ExplainerClient.js';
+export type { ExplainRequest, ExplainResponse, ExplainError, ExplainResult } from './ExplainerClient.js';

--- a/packages/ai-explainer/tsconfig.json
+++ b/packages/ai-explainer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["ES2020"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Implements the AI decision explanation layer as described in issue #176.

### Changes

#### `packages/ai-explainer/` (new shared package)
- `ExplainerClient` class that calls the RCC brain API
- Configurable via `RCC_URL` env var (default: `http://localhost:8789`)
- Gracefully returns 503 if RCC is unreachable or times out
- Exports types: `ExplainRequest`, `ExplainResponse`, `ExplainError`, `ExplainResult`

#### `apps/aviation-accident-tracker/backend`
- New `POST /api/explain` endpoint
- Accepts `{ context: string, question: string }`
- Returns `{ explanation: string }` on success or error with appropriate HTTP status

#### `apps/aviation-accident-tracker/frontend`
- Added **? Explain with AI** button to the event detail modal
- Calls `/api/explain` with the event's context (aircraft type, narrative, summary, etc.)
- Displays the AI explanation inline with loading and error states

### Notes
- v1 skeleton — intentionally minimal
- No new TypeScript compile errors introduced (`strict: false` already in backend tsconfig)
- Other app backends can add the same pattern by depending on `@aviation/ai-explainer`

Closes #176